### PR TITLE
include LICENSE and README in tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 recursive-include cinder *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff *.woff2
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+include README.md
+include LICENSE.md


### PR DESCRIPTION
Hi I am packaging this theme for Fedora and I wan to propose to include the License text and Readme in the pypi tarball.