### PR TITLE
show h3 headings in sidebar toc

### DIFF
--- a/cinder/css/base.css
+++ b/cinder/css/base.css
@@ -9,8 +9,12 @@ h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id
     height: 75px;
 }
 
-ul.nav li.main {
+ul.nav li.first-level {
     font-weight: bold;
+}
+
+ul.nav li.third-level {
+    padding-left: 12px;
 }
 
 div.col-md-3 {

--- a/cinder/toc.html
+++ b/cinder/toc.html
@@ -1,9 +1,12 @@
 <div class="bs-sidebar hidden-print affix well" role="complementary">
     <ul class="nav bs-sidenav">
     {% for toc_item in toc %}
-        <li class="main {% if toc_item.active %}active{% endif %}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+        <li class="first-level {% if toc_item.active %}active{% endif %}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
         {% for toc_item in toc_item.children %}
-            <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+            <li class="second-level"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+            {% for toc_item in toc_item.children %}
+                <li class="third-level"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+            {% endfor %}
         {% endfor %}
     {% endfor %}
     </ul>


### PR DESCRIPTION
I found it somewhat limiting to have just h1 and h2 in the table of contents, so I added a third level.

![screen shot 2016-02-14 at 12 15 39](https://cloud.githubusercontent.com/assets/28724/13033376/c7bbcab0-d314-11e5-9c14-27eaba488fac.png)
