### PR TITLE
Toggle search link in header with include_search

### DIFF
--- a/cinder/nav.html
+++ b/cinder/nav.html
@@ -42,11 +42,13 @@
             {% endif %}
 
             <ul class="nav navbar-nav navbar-right">
-                <li>
-                    <a href="#" data-toggle="modal" data-target="#mkdocs_search_modal">
-                        <i class="fa fa-search"></i> Search
-                    </a>
-                </li>
+                {% if include_search %}
+                    <li>
+                        <a href="#" data-toggle="modal" data-target="#mkdocs_search_modal">
+                            <i class="fa fa-search"></i> Search
+                        </a>
+                  </li>
+                {% endif %}
                 {% if include_next_prev %}
                     <li {% if not previous_page %}class="disabled"{% endif %}>
                         <a rel="next" {% if previous_page %}href="{{ previous_page.url }}"{% endif %}>

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,13 @@ pages:
 
 The link appears at the upper right hand corner of your site.
 
+### Toggle the search link
+
+A search link is provided in the upper right of the header by default. Toggle thesearch link on and off by including 'include_search' in the 'mkdocs.yml' file
+
+<pre><code class="yaml">extra:
+    include_search: false</code></pre>
+
 ### License Declaration and Link
 
 The Cinder theme displays your license declaration in the footer if you include a `copyright` field and define it with the text (and optionally the HTML link) that you would like to display:

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,9 +176,9 @@ pages:
 
 The link appears at the upper right hand corner of your site.
 
-### Toggle the search link
+### Toggle The Search Link
 
-A search link is provided in the upper right of the header by default. Toggle thesearch link on and off by including 'include_search' in the 'mkdocs.yml' file
+A search link is show in the header by default. Toggle the search link on and off by including 'include_search' in the 'mkdocs.yml' file
 
 <pre><code class="yaml">extra:
     include_search: false</code></pre>


### PR DESCRIPTION
I've added a yml variable 'include_search' to toggle the search link on and off in nav.html

what do you think?

p.s. This is the first time I have done a pull request on Github. Thus, I have NO IDEA what I am doing or if I have done this correctly.
