### PR TITLE
Focus on search box

### DIFF
--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -1,6 +1,32 @@
+function getSearchTerm()
+{
+    var sPageURL = window.location.search.substring(1);
+    var sURLVariables = sPageURL.split('&');
+    for (var i = 0; i < sURLVariables.length; i++)
+    {
+        var sParameterName = sURLVariables[i].split('=');
+        if (sParameterName[0] == 'q')
+        {
+            return sParameterName[1];
+        }
+    }
+}
 
-/* Highlight */
-$( document ).ready(function() {
+$(document).ready(function() {
+
+    var search_term = getSearchTerm(),
+        $search_modal = $('#mkdocs_search_modal');
+
+    if(search_term){
+        $search_modal.modal();
+    }
+
+    // make sure search input gets autofocus everytime modal opens.
+    $search_modal.on('shown.bs.modal', function () {
+        $search_modal.find('#mkdocs-search-query').focus();
+    });
+
+    // Highlight.js
     hljs.initHighlightingOnLoad();
     $('table').addClass('table table-striped table-hover');
 });
@@ -10,11 +36,7 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
-
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {
     event.preventDefault();
 });
-
-
-


### PR DESCRIPTION
The default installation for mkdocs had the auto focus on the search input field, so I copied the base.js to the `cinder` directory, and I'm kind of assuming here that this will work. Let me put it this way: as long as you haven't modified any of the html or css, I'm not really sure why this won't work... ; )
