### PR TITLE
Update the metadata templates to mkdocs 0.17

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -4,14 +4,13 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">{% if page_description %}
-    <meta name="description" content="{{ page_description }}">{% endif %} {% if site_author %}
-    <meta name="author" content="{{ site_author }}">{% endif %} {% if canonical_url %}
-    <link rel="canonical" href="{{ canonical_url }}">{% endif %} {% if favicon %}
-    <link rel="shortcut icon" href="{{ base_url }}/{{ favicon }}">{% else %}
-    <link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">{% if config.site_description %}
+    <meta name="description" content="{{ config.site_description }}">{% endif %} {% if config.site_author %}
+    <meta name="author" content="{{ config.site_author }}">{% endif %} {% if page.canonical_url %}
+    <link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
+    <link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">
 
-    <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}</title>
+    <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
 
     <link href="{{ base_url }}/css/bootstrap-custom.min.css" rel="stylesheet">
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
@@ -60,7 +59,7 @@
     {% endif %}
 </head>
 
-<body{% if current_page and current_page.is_homepage %} class="homepage" {% endif %}>
+<body{% if page and page.is_homepage %} class="homepage" {% endif %}>
 
     {% include "nav.html" %}
 
@@ -73,8 +72,8 @@
 
     <footer class="col-md-12 text-center">
         <hr>
-        <p>{% if copyright %}
-        <small>{{ copyright }}<br></small>
+        <p>{% if config.copyright %}
+        <small>{{ config.copyright }}<br></small>
         {% endif %}
         <small>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</p></small>
     </footer>
@@ -122,7 +121,7 @@
     </body>
 
 </html>
-{% if current_page and current_page.is_homepage %}
+{% if page and page.is_homepage %}
 <!--
 MkDocs version : {{ mkdocs_version }}
 Build Date UTC : {{ build_date_utc }}


### PR DESCRIPTION
This patch fixes the templates in `base.html` that have been changed in mkdocs 0.17. The page- and site parameters are now under `page` and `config`. In addition, the `favicon` option was dropped, so I removed its ıf-true branch.