### PR TITLE
Fix broken navigation links

### DIFF
--- a/cinder/nav-sub.html
+++ b/cinder/nav-sub.html
@@ -1,6 +1,6 @@
 {% if not nav_item.children %}
 <li {% if nav_item.active %}class="active"{% endif %}>
-    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+    <a href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
 </li>
 {% else %}
   <li class="dropdown-submenu">

--- a/cinder/nav.html
+++ b/cinder/nav.html
@@ -15,7 +15,7 @@
 
             <!-- Main title -->
 
-            <a class="navbar-brand" href="{{ nav.homepage.url }}">{{ config.site_name }}</a>
+            <a class="navbar-brand" href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
         </div>
 
         <!-- Expanded navigation -->
@@ -36,7 +36,7 @@
                     </li>
                 {% else %}
                     <li {% if nav_item.active %}class="active"{% endif %}>
-                        <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+                        <a href="{{ nav_item.url|url }}">{{ nav_item.title }}</a>
                     </li>
                 {% endif %}
                 {% endfor %}
@@ -58,12 +58,12 @@
                 {%- block next_prev %}
                     {%- if page and (page.next_page or page.previous_page) %}
                     <li {% if not page.previous_page %}class="disabled"{% endif %}>
-                        <a rel="next" {% if page.previous_page %}href="{{ page.previous_page.url }}"{% endif %}>
+                        <a rel="next" {% if page.previous_page %}href="{{ page.previous_page.url|url }}"{% endif %}>
                             <i class="fa fa-arrow-left"></i> Previous
                         </a>
                     </li>
                     <li {% if not page.next_page %}class="disabled"{% endif %}>
-                        <a rel="prev" {% if page.next_page %}href="{{ page.next_page.url }}"{% endif %}>
+                        <a rel="prev" {% if page.next_page %}href="{{ page.next_page.url|url }}"{% endif %}>
                             Next <i class="fa fa-arrow-right"></i>
                         </a>
                     </li>


### PR DESCRIPTION
With MkDocs 1.0, navigation links are currently broken due to yet another [API change](https://github.com/mkdocs/mkdocs/blob/master/docs/about/release-notes.md#template-variables-and-base_url). This patch fixes the problem.