### PR TITLE
Add an option for disabling the table of contents on some pages.

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -65,8 +65,12 @@
 
     <div class="container">
         {% block content %}
+        {% if page.meta.disable_toc %}
+        <div class="col-md-12" role="main">{% include "content.html" %}</div>
+        {% else %}
         <div class="col-md-3">{% include "toc.html" %}</div>
         <div class="col-md-9" role="main">{% include "content.html" %}</div>
+        {% endif %}
         {% endblock %}
     </div>
 


### PR DESCRIPTION
Whilst rewriting our documentation I have found that the table of contents is not necessary on some pages. This pull request adds an option to disable the TOC on a page-by-page basis using page metadata like so:

```yaml
---
disable_toc: true
---
```
