### PR TITLE
fix: ToC menu doesn't scroll when taller than browser window

### DIFF
--- a/cinder/css/base.css
+++ b/cinder/css/base.css
@@ -103,6 +103,7 @@ div.source-links {
     .bs-sidebar.affix {
         position: fixed; /* Undo the static from mobile first approach */
         top: 80px;
+        max-height: calc(100% - 90px);
     }
     .bs-sidebar.affix-bottom {
         position: absolute; /* Undo the static from mobile first approach */


### PR DESCRIPTION
Fixes https://github.com/chrissimpkins/cinder/issues/43.

Refer to https://caniuse.com/#feat=calc for browser compatibility.