### PR TITLE
Include page revision meta into footer block

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -85,10 +85,11 @@
         <small>{{ config.copyright }}<br></small>
         {% endif %}
         <small>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</p></small>
-        {% endblock %}
+        
         {% if page.meta.revision_date %}<br>
         <small>Revised on: {{ page.meta.revision_date }}</small>
         {% endif %}
+        {% endblock %}
     </footer>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>


### PR DESCRIPTION
Fixed the footer block to include the revision meta.

Issue #61 