### PR TITLE
Focus search input when opening search modal

### DIFF
--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -1,6 +1,4 @@
-
-/* Highlight */
-$( document ).ready(function() {
+$(document).ready(function() {
     hljs.initHighlightingOnLoad();
     $('table').addClass('table table-striped table-hover');
 });
@@ -10,11 +8,7 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
-
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {
     event.preventDefault();
 });
-
-
-

--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -1,8 +1,13 @@
 $(document).ready(function() {
     hljs.initHighlightingOnLoad();
-    $('table').addClass('table table-striped table-hover');
-});
 
+    $('table').addClass('table table-striped table-hover');
+
+    var $searchModal = $('#mkdocs_search_modal');
+    $searchModal.on('shown.bs.modal', function() {
+        $searchModal.find('#mkdocs-search-query').focus();
+    });
+});
 
 $('body').scrollspy({
     target: '.bs-sidebar',


### PR DESCRIPTION
Code is pretty much taken from [MkDocs default theme](https://github.com/mkdocs/mkdocs/blob/54a6e9efbc81ceb57f7aafb816d78ae5c4bb5e9b/mkdocs/themes/mkdocs/js/base.js#L26-L28). The used html ids can be found in base.html. I tested locally using `custom_dir`.

Another improvement could be made to the search modal: it is not closed when clicking a search result which refers to a section in the current page.