### PR TITLE
Fix 404 error page not generated

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -85,8 +85,8 @@
         <small>{{ config.copyright }}<br></small>
         {% endif %}
         <small>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</p></small>
-        
-        {% if page.meta.revision_date %}<br>
+
+        {% if page and page.meta.revision_date %}<br>
         <small>Revised on: {{ page.meta.revision_date }}</small>
         {% endif %}
         {% endblock %}

--- a/cinder/base.html
+++ b/cinder/base.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">{% if config.site_description %}
-    <meta name="description" content="{{ config.site_description }}">{% endif %} {% if config.site_author %}
-    <meta name="author" content="{{ config.site_author }}">{% endif %} {% if page.canonical_url %}
-    <link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
-    <link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% if config.site_description %}<meta name="description" content="{{ config.site_description }}">{% endif %}
+    {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
+    {% if page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
+    <link rel="{{ 'img/favicon.ico'|url }}">
 
     {% block htmltitle %}
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
@@ -18,13 +18,14 @@
     <link rel="stylesheet" href="//cdn.jsdelivr.net/font-hack/3.003/css/hack.min.css">
     <link href='//fonts.googleapis.com/css?family=PT+Sans:400,400italic,700,700italic&subset=latin-ext,latin' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,600,700&subset=latin-ext,latin' rel='stylesheet' type='text/css'>
-    <link href="{{ base_url }}/css/bootstrap-custom.min.css" rel="stylesheet">
-    <link href="{{ base_url }}/css/base.min.css" rel="stylesheet">
-    <link href="{{ base_url }}/css/cinder.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="{{ base_url }}/css/highlight.min.css">
+    <link href="{{ 'css/bootstrap-custom.min.css'|url }}" rel="stylesheet">
+    <link href="{{ 'css/base.min.css'|url }}" rel="stylesheet">
+    <link href="{{ 'css/cinder.min.css'|url }}" rel="stylesheet">
+    <link href="{{ 'css/highlight.min.css'|url }}" rel="stylesheet">
 
-    {%- for path in extra_css %}
-    <link href="{{ path }}" rel="stylesheet">{%- endfor %}
+    {%- for path in config['extra_css'] %}
+    <link href="{{ path|url }}" rel="stylesheet">
+    {%- endfor %}
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -93,16 +94,15 @@
     </footer>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-    <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
-    <script src="{{ base_url }}/js/highlight.pack.js"></script>
+    <script src="{{ 'js/bootstrap-3.0.3.min.js'|url }}"></script>
+    <script src="{{ 'js/highlight.pack.js'|url }}"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script>
     var base_url = '{{ base_url }}';
     </script>
-    <!-- <script data-main="{{ base_url }}/mkdocs/js/search.js" src="{{ base_url }}/mkdocs/js/require.js"></script> -->
-    <script src="{{ base_url }}/js/base.js"></script>
-    {%- for path in extra_javascript %}
-    <script src="{{ path }}"></script>
+    <script src="{{ 'js/base.js'|url }}"></script>
+    {%- for path in config['extra_javascript'] %}
+    <script src="{{ path|url }}"></script>
     {%- endfor %}
 
     <div class="modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-labelledby="Search Modal" aria-hidden="true">

--- a/cinder/mkdocs_theme.yml
+++ b/cinder/mkdocs_theme.yml
@@ -1,1 +1,4 @@
 cinder_theme: true
+
+static_templates:
+  - 404.html


### PR DESCRIPTION
It was mostly missing a `static_templates` entry. Also by using `url` filter, it prevents possible broken links when serving 404.html. I tested locally with `pip install .`.

Fixes issue #64 