### PR TITLE
Webfont.js url incorrect.

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -33,7 +33,7 @@
             <script src="https://cdn.jsdelivr.net/npm/respond.js@1.4.2/dest/respond.min.js"></script>
         <![endif]-->
 
-    <script src="//ajax.googleapis.com/ajax/libs/webfont/1.6.28/webfont.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
     <script>
     WebFont.load({
         google: {


### PR DESCRIPTION
Per https://developers.google.com/speed/libraries/#web-font-loader, google does not host 1.6.28. Setting to 1.6.26.