### PR TITLE
Got shortcuts mostly working.

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -106,7 +106,7 @@
     {%- endfor %}
 
     {% if 'search' in config['plugins'] %}{%- include "search-modal.html" %}{% endif %}
-
+    {%- include "keyboard-modal.html" %}
     </body>
 
 </html>

--- a/cinder/base.html
+++ b/cinder/base.html
@@ -92,18 +92,21 @@
         {% endif %}
         {% endblock %}
     </footer>
-
+    
+    {%- block scripts %}
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="{{ 'js/bootstrap-3.0.3.min.js'|url }}"></script>
     <script src="{{ 'js/highlight.pack.js'|url }}"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <script>
-    var base_url = '{{ base_url }}';
-    </script>
+    <script>var base_url = {{ base_url | tojson }}</script>
+    {% if config.theme.shortcuts %}
+        <script>var shortcuts = {{ config.theme.shortcuts | tojson }}</script>
+    {% endif %}
     <script src="{{ 'js/base.js'|url }}"></script>
     {%- for path in config['extra_javascript'] %}
     <script src="{{ path|url }}"></script>
     {%- endfor %}
+    {%- endblock %}
 
     {% if 'search' in config['plugins'] %}{%- include "search-modal.html" %}{% endif %}
     {%- include "keyboard-modal.html" %}

--- a/cinder/base.html
+++ b/cinder/base.html
@@ -105,32 +105,7 @@
     <script src="{{ path|url }}"></script>
     {%- endfor %}
 
-    <div class="modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-labelledby="Search Modal" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal">
-                        <span aria-hidden="true">&times;</span>
-                        <span class="sr-only">Close</span>
-                    </button>
-                    <h4 class="modal-title" id="exampleModalLabel">Search</h4>
-                </div>
-                <div class="modal-body">
-                    <p>
-                        From here you can search these documents. Enter your search terms below.
-                    </p>
-                    <form role="form">
-                        <div class="form-group">
-                            <input type="text" class="form-control" placeholder="Search..." id="mkdocs-search-query">
-                        </div>
-                    </form>
-                    <div id="mkdocs-search-results"></div>
-                </div>
-                <div class="modal-footer">
-                </div>
-            </div>
-        </div>
-    </div>
+    {% if 'search' in config['plugins'] %}{%- include "search-modal.html" %}{% endif %}
 
     </body>
 

--- a/cinder/base.html
+++ b/cinder/base.html
@@ -99,8 +99,8 @@
     <script src="{{ 'js/highlight.pack.js'|url }}"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script>var base_url = {{ base_url | tojson }}</script>
-    {% if config.theme.shortcuts %}
-        <script>var shortcuts = {{ config.theme.shortcuts | tojson }}</script>
+    {% if config.shortcuts %}
+        <script>var shortcuts = {{ config.shortcuts | tojson }}</script>
     {% endif %}
     <script src="{{ 'js/base.js'|url }}"></script>
     {%- for path in config['extra_javascript'] %}

--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -13,21 +13,221 @@ function getSearchTerm()
 }
 
 $(document).ready(function() {
+    /**
+     * ------------------------------------------------------------------------
+     * Cinder theme specific
+     * ------------------------------------------------------------------------
+     */
     hljs.initHighlightingOnLoad();
+
+
+    /**
+     * ------------------------------------------------------------------------
+     * Taken from themes/mkdocs/js/base.js
+     * ------------------------------------------------------------------------
+     */
+    var search_term = getSearchTerm(),
+    $search_modal = $('#mkdocs_search_modal'),
+    $keyboard_modal = $('#mkdocs_keyboard_modal');
+
+    if(search_term){
+        $search_modal.modal();
+    }
+
+    // make sure search input gets autofocus everytime modal opens.
+    $search_modal.on('shown.bs.modal', function () {
+        $search_modal.find('#mkdocs-search-query').focus();
+    });
+
+    // Close search modal when result is selected
+    // The links get added later so listen to parent
+    $('#mkdocs-search-results').click(function(e) {
+      if ($(e.target).is('a')) {
+        $search_modal.modal('hide');
+      }
+    });
+
+    // Populate keyboard modal with proper Keys
+    $keyboard_modal.find('.help.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.help];
+    $keyboard_modal.find('.prev.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.previous];
+    $keyboard_modal.find('.next.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.next];
+    $keyboard_modal.find('.search.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.search];
+
+    // Keyboard navigation
+    document.addEventListener("keydown", function(e) {
+        if ($(e.target).is(':input')) return true;
+        var key = e.which || e.keyCode || window.event && window.event.keyCode;
+        var page;
+        switch (key) {
+            case shortcuts.next:
+                page = $('.navbar a[rel="next"]:first').prop('href');
+                break;
+            case shortcuts.previous:
+                page = $('.navbar a[rel="prev"]:first').prop('href');
+                break;
+            case shortcuts.search:
+                e.preventDefault();
+                $keyboard_modal.modal('hide');
+                $search_modal.modal('show');
+                $search_modal.find('#mkdocs-search-query').focus();
+                break;
+            case shortcuts.help:
+                $search_modal.modal('hide');
+                $keyboard_modal.modal('show');
+                break;
+            default: break;
+        }
+        if (page) {
+            $keyboard_modal.modal('hide');
+            window.location.href = page;
+        }
+    });
 
     $('table').addClass('table table-striped table-hover');
 
-    var $searchModal = $('#mkdocs_search_modal');
-    $searchModal.on('shown.bs.modal', function() {
-        $searchModal.find('#mkdocs-search-query').focus();
+    // Improve the scrollspy behaviour when users click on a TOC item.
+    $(".bs-sidenav a").on("click", function() {
+        var clicked = this;
+        setTimeout(function() {
+            var active = $('.nav li.active a');
+            active = active[active.length - 1];
+            if (clicked !== active) {
+                $(active).parent().removeClass("active");
+                $(clicked).parent().addClass("active");
+            }
+        }, 50);
     });
 });
 
+
+/**
+ * ------------------------------------------------------------------------
+ * Taken from themes/mkdocs/js/base.js
+ * ------------------------------------------------------------------------
+ */
+
 $('body').scrollspy({
     target: '.bs-sidebar',
+    offset: 100
 });
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {
     event.preventDefault();
 });
+
+// See https://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes
+// We only list common keys below. Obscure keys are omited and their use is discouraged.
+var keyCodes = {
+  8: 'backspace',
+  9: 'tab',
+  13: 'enter',
+  16: 'shift',
+  17: 'ctrl',
+  18: 'alt',
+  19: 'pause/break',
+  20: 'caps lock',
+  27: 'escape',
+  32: 'spacebar',
+  33: 'page up',
+  34: 'page down',
+  35: 'end',
+  36: 'home',
+  37: '&larr;',
+  38: '&uarr;',
+  39: '&rarr;',
+  40: '&darr;',
+  45: 'insert',
+  46: 'delete',
+  48: '0',
+  49: '1',
+  50: '2',
+  51: '3',
+  52: '4',
+  53: '5',
+  54: '6',
+  55: '7',
+  56: '8',
+  57: '9',
+  65: 'a',
+  66: 'b',
+  67: 'c',
+  68: 'd',
+  69: 'e',
+  70: 'f',
+  71: 'g',
+  72: 'h',
+  73: 'i',
+  74: 'j',
+  75: 'k',
+  76: 'l',
+  77: 'm',
+  78: 'n',
+  79: 'o',
+  80: 'p',
+  81: 'q',
+  82: 'r',
+  83: 's',
+  84: 't',
+  85: 'u',
+  86: 'v',
+  87: 'w',
+  88: 'x',
+  89: 'y',
+  90: 'z',
+  91: 'Left Windows Key / Left ⌘',
+  92: 'Right Windows Key',
+  93: 'Windows Menu / Right ⌘',
+  96: 'numpad 0',
+  97: 'numpad 1',
+  98: 'numpad 2',
+  99: 'numpad 3',
+  100: 'numpad 4',
+  101: 'numpad 5',
+  102: 'numpad 6',
+  103: 'numpad 7',
+  104: 'numpad 8',
+  105: 'numpad 9',
+  106: 'multiply',
+  107: 'add',
+  109: 'subtract',
+  110: 'decimal point',
+  111: 'divide',
+  112: 'f1',
+  113: 'f2',
+  114: 'f3',
+  115: 'f4',
+  116: 'f5',
+  117: 'f6',
+  118: 'f7',
+  119: 'f8',
+  120: 'f9',
+  121: 'f10',
+  122: 'f11',
+  123: 'f12',
+  124: 'f13',
+  125: 'f14',
+  126: 'f15',
+  127: 'f16',
+  128: 'f17',
+  129: 'f18',
+  130: 'f19',
+  131: 'f20',
+  132: 'f21',
+  133: 'f22',
+  134: 'f23',
+  135: 'f24',
+  144: 'num lock',
+  145: 'scroll lock',
+  186: '&semi;',
+  187: '&equals;',
+  188: '&comma;',
+  189: '&hyphen;',
+  190: '&period;',
+  191: '&quest;',
+  192: '&grave;',
+  219: '&lsqb;',
+  220: '&bsol;',
+  221: '&rsqb;',
+  222: '&apos;',
+};

--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -57,7 +57,7 @@ $(document).ready(function() {
       // Keyboard navigation
       document.addEventListener("keydown", function(e) {
           if ($(e.target).is(':input')) return true;
-          var key = e.which || e.keyCode || window.event && window.event.keyCode;
+          var key = e.which || e.key || window.event && window.event.key;
           var page;
           switch (key) {
               case shortcuts.next:

--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -1,3 +1,17 @@
+function getSearchTerm()
+{
+    var sPageURL = window.location.search.substring(1);
+    var sURLVariables = sPageURL.split('&');
+    for (var i = 0; i < sURLVariables.length; i++)
+    {
+        var sParameterName = sURLVariables[i].split('=');
+        if (sParameterName[0] == 'q')
+        {
+            return sParameterName[1];
+        }
+    }
+}
+
 $(document).ready(function() {
     hljs.initHighlightingOnLoad();
 

--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -47,41 +47,43 @@ $(document).ready(function() {
       }
     });
 
-    // Populate keyboard modal with proper Keys
-    $keyboard_modal.find('.help.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.help];
-    $keyboard_modal.find('.prev.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.previous];
-    $keyboard_modal.find('.next.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.next];
-    $keyboard_modal.find('.search.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.search];
+    if (typeof shortcuts !== 'undefined') {
+      // Populate keyboard modal with proper Keys
+      $keyboard_modal.find('.help.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.help];
+      $keyboard_modal.find('.prev.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.previous];
+      $keyboard_modal.find('.next.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.next];
+      $keyboard_modal.find('.search.shortcut kbd')[0].innerHTML = keyCodes[shortcuts.search];
 
-    // Keyboard navigation
-    document.addEventListener("keydown", function(e) {
-        if ($(e.target).is(':input')) return true;
-        var key = e.which || e.keyCode || window.event && window.event.keyCode;
-        var page;
-        switch (key) {
-            case shortcuts.next:
-                page = $('.navbar a[rel="next"]:first').prop('href');
-                break;
-            case shortcuts.previous:
-                page = $('.navbar a[rel="prev"]:first').prop('href');
-                break;
-            case shortcuts.search:
-                e.preventDefault();
-                $keyboard_modal.modal('hide');
-                $search_modal.modal('show');
-                $search_modal.find('#mkdocs-search-query').focus();
-                break;
-            case shortcuts.help:
-                $search_modal.modal('hide');
-                $keyboard_modal.modal('show');
-                break;
-            default: break;
-        }
-        if (page) {
-            $keyboard_modal.modal('hide');
-            window.location.href = page;
-        }
-    });
+      // Keyboard navigation
+      document.addEventListener("keydown", function(e) {
+          if ($(e.target).is(':input')) return true;
+          var key = e.which || e.keyCode || window.event && window.event.keyCode;
+          var page;
+          switch (key) {
+              case shortcuts.next:
+                  page = $('.navbar a[rel="next"]:first').prop('href');
+                  break;
+              case shortcuts.previous:
+                  page = $('.navbar a[rel="prev"]:first').prop('href');
+                  break;
+              case shortcuts.search:
+                  e.preventDefault();
+                  $keyboard_modal.modal('hide');
+                  $search_modal.modal('show');
+                  $search_modal.find('#mkdocs-search-query').focus();
+                  break;
+              case shortcuts.help:
+                  $search_modal.modal('hide');
+                  $keyboard_modal.modal('show');
+                  break;
+              default: break;
+          }
+          if (page) {
+              $keyboard_modal.modal('hide');
+              window.location.href = page;
+          }
+      });
+    }
 
     $('table').addClass('table table-striped table-hover');
 

--- a/cinder/keyboard-modal.html
+++ b/cinder/keyboard-modal.html
@@ -1,0 +1,40 @@
+<div class="modal" id="mkdocs_keyboard_modal" tabindex="-1" role="dialog" aria-labelledby="keyboardModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="keyboardModalLabel">Keyboard Shortcuts</h4>
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+            </div>
+            <div class="modal-body">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th style="width: 20%;">Keys</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td class="help shortcut"><kbd>?</kbd></td>
+                    <td>Open this help</td>
+                  </tr>
+                  <tr>
+                    <td class="next shortcut"><kbd>n</kbd></td>
+                    <td>Next page</td>
+                  </tr>
+                  <tr>
+                    <td class="prev shortcut"><kbd>p</kbd></td>
+                    <td>Previous page</td>
+                  </tr>
+                  <tr>
+                    <td class="search shortcut"><kbd>s</kbd></td>
+                    <td>Search</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="modal-footer">
+            </div>
+        </div>
+    </div>
+</div>

--- a/cinder/mkdocs_theme.yml
+++ b/cinder/mkdocs_theme.yml
@@ -2,3 +2,12 @@ cinder_theme: true
 
 static_templates:
   - 404.html
+
+include_search_page: false
+search_index_only: false
+
+shortcuts:
+    help: 191    # ?
+    next: 78     # n
+    previous: 80 # p
+    search: 83   # s

--- a/cinder/nav.html
+++ b/cinder/nav.html
@@ -58,12 +58,12 @@
                 {%- block next_prev %}
                     {%- if page and (page.next_page or page.previous_page) %}
                     <li {% if not page.previous_page %}class="disabled"{% endif %}>
-                        <a rel="next" {% if page.previous_page %}href="{{ page.previous_page.url|url }}"{% endif %}>
+                        <a rel="prev" {% if page.previous_page %}href="{{ page.previous_page.url|url }}"{% endif %}>
                             <i class="fas fa-arrow-left"></i> Previous
                         </a>
                     </li>
                     <li {% if not page.next_page %}class="disabled"{% endif %}>
-                        <a rel="prev" {% if page.next_page %}href="{{ page.next_page.url|url }}"{% endif %}>
+                        <a rel="next" {% if page.next_page %}href="{{ page.next_page.url|url }}"{% endif %}>
                             Next <i class="fas fa-arrow-right"></i>
                         </a>
                     </li>

--- a/cinder/search-modal.html
+++ b/cinder/search-modal.html
@@ -1,0 +1,24 @@
+<div class="modal" id="mkdocs_search_modal" tabindex="-1" role="dialog" aria-labelledby="searchModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="searchModalLabel">Search</h4>
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    From here you can search these documents. Enter
+                    your search terms below.
+                </p>
+                <form>
+                    <div class="form-group">
+                        <input type="text" class="form-control" placeholder="Search..." id="mkdocs-search-query" title="Type search term here">
+                    </div>
+                </form>
+                <div id="mkdocs-search-results"></div>
+            </div>
+            <div class="modal-footer">
+            </div>
+        </div>
+    </div>
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,19 @@ nav:
   - Home: index.md
   - About: about.md</code></pre>
 
+### Keyboard shortcuts
+
+In your `mkdocs.yml` file, place the following to enable keyboard shortcuts. 
+
+```
+shortcuts:
+    help: 191    # ?
+    next: 39     # right arrow
+    previous: 37 # left arrow
+    search: 83   # s
+```
+
+The numbers correspond to the key that you would like to use for that shortcut. You can use [https://keycode.info/](https://keycode.info/) to find the keycode you want.
 
 ### Extending Cinder
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,8 +9,3 @@ nav:
   - Specimen: specimen.md
 markdown_extensions:
   - admonition
-shortcuts:
-    help: 191    # ?
-    next: 78     # n
-    previous: 80 # p
-    search: 83   # s

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,3 +9,8 @@ nav:
   - Specimen: specimen.md
 markdown_extensions:
   - admonition
+shortcuts:
+    help: 191    # ?
+    next: 78     # n
+    previous: 80 # p
+    search: 83   # s


### PR DESCRIPTION
I got shortcuts working with a caveat. 

### Caveat
- I'm not familiar enough with this codebase and the templating hierarchy to understand how the .yml config variables are being set in the cinder/mkdocs.yml, cinder/cinder/mkdocs_theme.yml, and my mkdocs/mkdocs.yml. 

This basically means that whoever is using this, must add the shortcuts settings in their mkdocs.yml file where they set their theme. So something like this...

### mkdocs.yml
```
theme:
  name: null
  custom_dir: 'custom/themes/cinder/cinder'
shortcuts:
    help: 191    # ?
    next: 39     # right arrow
    previous: 37 # left arrow
    search: 83   # s
```

If `shortcuts` is missing from the .yml file then no shortcut keys are active. 

Would be nice if someone could figure out how to set the default shortcut keys in the proper .yml file. That would get rid of the `if` conditionals I put in base.html and base.js to check for `shortcuts`.