### PR TITLE
Fix search modal close button alignment

### DIFF
--- a/cinder/search-modal.html
+++ b/cinder/search-modal.html
@@ -2,8 +2,11 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
                 <h4 class="modal-title" id="searchModalLabel">Search</h4>
-                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
             </div>
             <div class="modal-body">
                 <p>


### PR DESCRIPTION
[Someone](https://github.com/chrissimpkins/cinder/pull/71) swapped the order of the title and the close button of the search modal, causing some alignment bugs:

![image](https://user-images.githubusercontent.com/4354863/68693777-2b5dbf80-0578-11ea-8bb8-9a72a1bc0c90.png)

This patch fixes the issue.