### PR TITLE
Corrected closing of tags in footer

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -84,7 +84,8 @@
         <p>{% if config.copyright %}
         <small>{{ config.copyright }}<br></small>
         {% endif %}
-        <small>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</p></small>
+        <small>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</small>
+        </p>
 
         {% if page and page.meta.revision_date %}<br>
         <small>Revised on: {{ page.meta.revision_date }}</small>


### PR DESCRIPTION
The small tag should be inside of the paragraph tag as the small tag is opened within the paragraph. 