### PR TITLE
Fix: restore default highlightjs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.0.4
+
+- fixed: default highlightjs support is supposed to be active by default and is not supposed to require configuration in the `mkdocs.yml` file.  This behavior was restored after recent changes.  highlightjs support can be removed by setting `theme > highlightjs` to `false`.
+
 ### v1.0.3
 
 - fixed: favicon link

--- a/cinder/base.html
+++ b/cinder/base.html
@@ -23,7 +23,9 @@
     <link href="{{ 'css/base.min.css'|url }}" rel="stylesheet">
     <link href="{{ 'css/cinder.min.css'|url }}" rel="stylesheet">
 
-    {% if config.theme.highlightjs %}
+    {% if config.theme.highlightjs is defined and config.theme.highlightjs is sameas false %} 
+
+    {% else %}
         {% if config.theme.colorscheme %}
         <link rel="stylesheet" href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.18.0/build/styles/{{ config.theme.colorscheme }}.min.css">
         {% else %}
@@ -96,13 +98,19 @@
     {%- block scripts %}
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="{{ 'js/bootstrap-3.0.3.min.js'|url }}"></script>
-    {% if config.theme.highlightjs %}
+
+    {% if config.theme.highlightjs is defined and config.theme.highlightjs is sameas false %}  <!-- default is to include highlightjs -->
+    
+    {% else %}
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.18.0/build/highlight.min.js"></script>
-    {%- for lang in config.theme.hljs_languages %}
-    <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.18.0/build/languages/{{lang}}.min.js"></script>
-    {%- endfor %}
+        {% if config.theme.hljs_languages %}
+            {%- for lang in config.theme.hljs_languages %}
+                <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.18.0/build/languages/{{lang}}.min.js"></script>
+            {%- endfor %}
+        {% endif %}
     <script>hljs.initHighlightingOnLoad();</script>
     {% endif %}
+
     <script>var base_url = {{ base_url | tojson }}</script>
     {% if config.shortcuts %}
         <script>var shortcuts = {{ config.shortcuts | tojson }}</script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Then navigate to the root of your project directory:
 
 Download the Cinder theme archive by clicking the button below.
 
-<a href="https://github.com/chrissimpkins/cinder/archive/v1.0.3.zip"><button type="button" class="btn btn-success"><i class="fas fa-cloud-download-alt fa-3x"></i> </br>  <span style="font-size:20px;">Download Cinder</span></button></a>
+<a href="https://github.com/chrissimpkins/cinder/archive/v1.0.4.zip"><button type="button" class="btn btn-success"><i class="fas fa-cloud-download-alt fa-3x"></i> </br>  <span style="font-size:20px;">Download Cinder</span></button></a>
 
 Unpack the contents of the archive into a directory named `cinder` at the top level of your MkDocs project directory.
 

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,18 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.0.3'
+VERSION = "1.0.4"
 
 
 setup(
     name="mkdocs-cinder",
     version=VERSION,
-    url='https://github.com/chrissimpkins/cinder',
-    license='MIT',
-    description='A clean responsive theme for the MkDocs static documentation site generator',
-    author='Christopher Simpkins',
-    author_email='chris@sourcefoundry.org',
+    url="https://github.com/chrissimpkins/cinder",
+    license="MIT",
+    description="A clean responsive theme for the MkDocs static documentation site generator",
+    author="Christopher Simpkins",
+    author_email="chris@sourcefoundry.org",
     packages=find_packages(),
     include_package_data=True,
-    entry_points={
-        'mkdocs.themes': [
-            'cinder = cinder',
-        ]
-    },
-    zip_safe=False
+    entry_points={"mkdocs.themes": ["cinder = cinder",]},
+    zip_safe=False,
 )


### PR DESCRIPTION
This PR replaces support for the default highlightjs language and theme sets by default in this theme.  

Support will now be available with the following `mkdocs.yml` settings:

#### Undefined `theme::highlightjs` configuration

```yaml
theme:
  name: null
  custom_dir: cinder
```

#### Define `theme::highlightjs` as `true`

```yaml
theme:
  name: null
  custom_dir: cinder
  highlightjs: true
```

### Toggle `highlightjs` **off**

#### Define `theme::highlightjs` as `false`

```yaml
theme:
  name: null
  custom_dir: cinder
  highlightjs: false
```

Closes #90
