### PR TITLE
Change "overflow-y" to "auto" for sidebar

### DIFF
--- a/cinder/css/base.css
+++ b/cinder/css/base.css
@@ -103,8 +103,8 @@ div.source-links {
     .bs-sidebar.affix {
         position: fixed; /* Undo the static from mobile first approach */
         top: 80px;
-        max-height: 85%;
-        overflow-y: scroll;
+        max-height: calc(100% - 180px);
+        overflow-y: auto;
     }
     .bs-sidebar.affix-bottom {
         position: absolute; /* Undo the static from mobile first approach */


### PR DESCRIPTION
With overflow "auto", scrollbar is not shown if not needed. Otherwise I think it's equivalent to "scroll".

Also modified height so it doesn't overlap footer.