### PR TITLE
Add feature toggles to disable parts of the theme without overriding its files

### DIFF
--- a/cinder/base.html
+++ b/cinder/base.html
@@ -80,20 +80,25 @@
         {% endblock %}
     </div>
 
-    <footer class="col-md-12 text-center">
-        {% block footer %}
-        <hr>
-        <p>{% if config.copyright %}
-        <small>{{ config.copyright }}</small><br>
-        {% endif %}
-        <small>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</small>
-        </p>
+    {% if not config.theme.disable_footer %}
+      <footer class="col-md-12 text-center">
+          {% block footer %}
+          <hr>
 
-        {% if page and page.meta.revision_date %}<br>
-        <small>Revised on: {{ page.meta.revision_date }}</small>
-        {% endif %}
-        {% endblock %}
-    </footer>
+          {% if not config.theme.disable_footer_except_revision %}
+            <p>{% if config.copyright %}
+            <small>{{ config.copyright }}</small><br>
+            {% endif %}
+            <small>Documentation built with <a href="http://www.mkdocs.org/">MkDocs</a>.</small>
+            </p>
+          {% endif %}
+
+          {% if page and page.meta.revision_date %}<br>
+          <small>Revised on: {{ page.meta.revision_date }}</small>
+          {% endif %}
+          {% endblock %}
+      </footer>
+    {% endif %}
 
     {%- block scripts %}
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>

--- a/cinder/base.html
+++ b/cinder/base.html
@@ -83,9 +83,8 @@
     {% if not config.theme.disable_footer %}
       <footer class="col-md-12 text-center">
           {% block footer %}
-          <hr>
-
           {% if not config.theme.disable_footer_except_revision %}
+            <hr>
             <p>{% if config.copyright %}
             <small>{{ config.copyright }}</small><br>
             {% endif %}
@@ -93,8 +92,9 @@
             </p>
           {% endif %}
 
-          {% if page and page.meta.revision_date %}<br>
-          <small>Revised on: {{ page.meta.revision_date }}</small>
+          {% if page and page.meta.revision_date %}
+          {% if config.theme.disable_footer_except_revision %}<hr>{% else %}<br>{% endif %}
+            <small>Revised on: {{ page.meta.revision_date }}</small>
           {% endif %}
           {% endblock %}
       </footer>

--- a/cinder/nav.html
+++ b/cinder/nav.html
@@ -15,7 +15,9 @@
 
             <!-- Main title -->
 
-            <a class="navbar-brand" href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
+            {% if not config.theme.disable_nav_site_name %}
+              <a class="navbar-brand" href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
+            {% endif %}
         </div>
 
         <!-- Expanded navigation -->
@@ -46,7 +48,7 @@
 
             <ul class="nav navbar-nav navbar-right">
                 {%- block search_button %}
-                    {%- if 'search' in config['plugins'] %}
+                    {%- if 'search' in config['plugins'] and not config.theme.disable_nav_search %}
                     <li>
                         <a href="#" data-toggle="modal" data-target="#mkdocs_search_modal">
                             <i class="fas fa-search"></i> Search
@@ -56,7 +58,7 @@
                 {%- endblock %}
 
                 {%- block next_prev %}
-                    {%- if page and (page.next_page or page.previous_page) %}
+                    {%- if page and (page.next_page or page.previous_page) and not config.theme.disable_nav_previous_next %}
                     <li {% if not page.previous_page %}class="disabled"{% endif %}>
                         <a rel="prev" {% if page.previous_page %}href="{{ page.previous_page.url|url }}"{% endif %}>
                             <i class="fas fa-arrow-left"></i> Previous

--- a/docs/index.md
+++ b/docs/index.md
@@ -307,6 +307,25 @@ nav:
   - Home: index.md
   - About: about.md</code></pre>
 
+### Disabling Theme Features
+
+The Cinder theme can turn off some theme features entirely in `mkdocs.yml`, for situations where you don't need these features. If this is all the customization required, it saves overriding theme files. For example:
+
+```yml
+theme:
+  name: cinder
+  # Turn off Previous/Next navigation links in the navbar
+  disable_nav_previous_next: true
+  # Turn off Search in the navbar
+  disable_nav_search: true
+  # Turn off the site_name link in the navbar
+  disable_nav_site_name: true
+  # Turn off the footer entirely
+  disable_footer: true
+  # Turn off the default footer message, but display the page revision date if it's available
+  disable_footer_except_revision: true
+```
+
 ## Issues
 
 If you have any issues with the theme, please report them on the Cinder repository:


### PR DESCRIPTION
Several toggles which are settable in `mkdocs.yml` to allow for turning
theme features off. Often you (or at least I!) want to turn things off,
but have no need to make further customizations.

The ones I came up with are:

* `disable_nav_previous_next`: Turn off Previous/Next navigation links in the navbar
* `disable_nav_search`: Turn off Search in the navbar
* `disable_nav_site_name`: Turn off the site_name link in the navbar
* `disable_footer`: Turn off the footer entirely
* `disable_footer_except_revision`: Turn off the default footer message, but display the page revision date if it's available

Closes #10
Closes #97