### PR TITLE
Fix extra javascript

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -210,11 +210,11 @@ Your CSS styles fall at the end of the cascade and will override all styles incl
 
 ### Add Your Own JavaScript
 
-Create a `js` directory inside your `docs` directory and add your JS files.  Then include your JS files in the `mkdocs.yml` file with the `extra_js` field:
+Create a `js` directory inside your `docs` directory and add your JS files.  Then include your JS files in the `mkdocs.yml` file with the `extra_javascript` field:
 
 <pre><code class="yaml">site_name: [YOURPROJECT]
 theme: cinder
-extra_js:
+extra_javascript:
   - "js/myscript.js"
   - "js/myotherscript.js"
 nav:


### PR DESCRIPTION
Right now with mkdocs 1.1.2 this fails with:

```
WARNING -  Config value: 'extra_js'. Warning: Unrecognised configuration name: extra_js
```
mkdocs [shows this](https://www.mkdocs.org/user-guide/configuration/#extra_javascript) is `extra_javascript`